### PR TITLE
Script improvements

### DIFF
--- a/faculty-environment.sh
+++ b/faculty-environment.sh
@@ -4,8 +4,7 @@ echo "Copying performance environment variables file to /etc/faculty_environment
 echo LD_LIBRARY_PATH=$PWD/examples:'$LD_LIBRARY_PATH' | sudo tee /etc/faculty_environment.d/performance_envs.sh
 
 echo "CD into install-boost..."
-TMP_DIR=$(pwd)
-cd install-boost
+pushd install-boost
 
 echo "Installing Boost..."
 source install_boost.sh
@@ -17,7 +16,6 @@ echo "Restarting Jupyter..."
 sudo sv stop jupyter && sudo sv start jupyter
 
 echo "Step back..."
-cd $TMP_DIR 
-unset TMP_DIR
+popd
 
 echo "Done."

--- a/faculty-environment.sh
+++ b/faculty-environment.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Copying performance environment variables file to /etc/faculty_environment..."
-sudo echo LD_LIBRARY_PATH=$PWD/examples:'$LD_LIBRARY_PATH' > /etc/faculty_environment.d/performance_envs.sh
+echo LD_LIBRARY_PATH=$PWD/examples:'$LD_LIBRARY_PATH' | sudo tee /etc/faculty_environment.d/performance_envs.sh
 
 echo "CD into install-boost..."
 TMP_DIR=$(pwd)

--- a/faculty-environment.sh
+++ b/faculty-environment.sh
@@ -13,7 +13,7 @@ echo "Copying environment variables file to /etc/faculty_environment.d ..."
 cp envs.sh /etc/faculty_environment.d/boost_envs.sh
 
 echo "Restarting Jupyter..."
-sudo sv stop jupyter && sudo sv start jupyter
+sudo sv restart jupyter
 
 echo "Step back..."
 popd

--- a/faculty-environment.sh
+++ b/faculty-environment.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Copying performance environment variables file to /etc/faculty_environment..."
-sudo echo $(echo LD_LIBRARY_PATH=$PWD/examples:'$LD_LIBRARY_PATH') > /etc/faculty_environment.d/performance_envs.sh
+sudo echo LD_LIBRARY_PATH=$PWD/examples:'$LD_LIBRARY_PATH' > /etc/faculty_environment.d/performance_envs.sh
 
 echo "CD into install-boost..."
 TMP_DIR=$(pwd)

--- a/faculty-environment.sh
+++ b/faculty-environment.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Copying performance environment variables file to /etc/faculty_environment..."
-sudo echo $(echo LD_LIBRARY_PATH=$(pwd)/examples:'$LD_LIBRARY_PATH') > /etc/faculty_environment.d/performance_envs.sh
+sudo echo $(echo LD_LIBRARY_PATH=$PWD/examples:'$LD_LIBRARY_PATH') > /etc/faculty_environment.d/performance_envs.sh
 
 echo "CD into install-boost..."
 TMP_DIR=$(pwd)


### PR DESCRIPTION
- Use `$PWD` instead of running `pwd` in sub-shell.
- Remove sub-shell and additional call to `echo`.
- Use `sudo tee` instead of `sudo echo`. `sudo echo` doesn't work as expected, as the redirection (`>`) is performed by the shell as the current user, not by `sudo` as `root`. `echo`-ing to `sudo tee` writes to the file as `root`, as intended.
- Use `pushd` and `popd` to move to another directory. `pushd` and `popd` are builtin bash commands that allow you to manage the directory stack.
- Restart Jupyter server with a single command.